### PR TITLE
Add wrist camera to tahoma description

### DIFF
--- a/tahoma_description/launch/camera_wrist_transform.launch
+++ b/tahoma_description/launch/camera_wrist_transform.launch
@@ -1,0 +1,7 @@
+<launch>
+  <!-- The rpy in the comment uses the extrinsic XYZ convention, which is the same as is used in a URDF. See
+       http://wiki.ros.org/geometry2/RotationMethods and https://en.wikipedia.org/wiki/Euler_angles for more info. -->
+
+  <node pkg="tf2_ros" type="static_transform_publisher" name="camera_wrist_broadcaster"
+      args="0 0 0 0 0 0 camera_wrist_mount camera_wrist_link" />
+</launch>

--- a/tahoma_description/launch/view_models.launch
+++ b/tahoma_description/launch/view_models.launch
@@ -20,6 +20,7 @@
   <!-- These should override the nominal values from the URDF -->
   <include file="$(find tahoma_description)/launch/camera_lower_right_transform.launch" />
   <include file="$(find tahoma_description)/launch/camera_lower_left_transform.launch" />
+  <include file="$(find tahoma_description)/launch/camera_wrist_transform.launch" />
 
   <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(find tahoma_description)/config/view_model.rviz"/>
 </launch>

--- a/tahoma_description/urdf/tahoma.xacro
+++ b/tahoma_description/urdf/tahoma.xacro
@@ -192,6 +192,14 @@
               rpy="0 ${radians(15)} 0"/>
     </joint>
 
+    <!-- Wrist Camera -->
+    <link name="camera_wrist_mount"/>
+    <joint name="arm_wrist_3_link_camera_wrist_mount_joint" type="fixed">
+        <parent link="arm_wrist_3_link"/>
+        <child link="camera_wrist_mount"/>
+        <origin xyz="0.07 0.00 0.00" rpy="${pi} ${-pi / 2} 0"/>
+    </joint>
+
     <xacro:if value="${realsense}">
       <xacro:sensor_l515 name="camera_lower_right" parent="camera_lower_right_mount" use_nominal_extrinsics="${use_nominal_camera_extrinsics}">
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -213,6 +221,11 @@
       <xacro:sensor_l515 name="camera_upper_left" parent="camera_upper_left_mount" use_nominal_extrinsics="${use_nominal_camera_extrinsics}">
         <origin xyz="0 0 0" rpy="0 0 0"/>
       </xacro:sensor_l515> -->
+
+      <!-- Wrist Camera -->
+      <xacro:sensor_l515 name="camera_wrist" parent="camera_wrist_mount" use_nominal_extrinsics="${use_nominal_camera_extrinsics}">
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+      </xacro:sensor_l515>
     </xacro:if>
   </xacro:macro>
 

--- a/tahoma_description/urdf/tahoma.xacro
+++ b/tahoma_description/urdf/tahoma.xacro
@@ -197,7 +197,7 @@
     <joint name="arm_wrist_3_link_camera_wrist_mount_joint" type="fixed">
         <parent link="arm_wrist_3_link"/>
         <child link="camera_wrist_mount"/>
-        <origin xyz="0.07 0.00 0.00" rpy="${pi} ${-pi / 2} 0"/>
+        <origin xyz="0.00 -0.07 0.00" rpy="${pi/2} ${-pi / 2} 0"/>
     </joint>
 
     <xacro:if value="${realsense}">


### PR DESCRIPTION
I followed the same pattern as camera_lower_left to add the camera to the tf tree and xacro.

I also had to modify aurmr_sim (see this PR: https://github.com/au-rmr/aurmr_sim/pull/1)