### PR TITLE
Release gripper when no item postgrasp

### DIFF
--- a/aurmr_tasks/scripts/aurmr_demo
+++ b/aurmr_tasks/scripts/aurmr_demo
@@ -167,6 +167,7 @@ def main():
             StateMachine.add_auto("MOVE_TO_GRASP", motion.grasp_move_to_offset(robot, (0, 0, 0.300)), ["succeeded", "aborted", "preempted"])
             StateMachine.add_auto("LIFT_OBJ", motion.robust_move_to_offset(robot, (0, 0, 0.035), 'base_link'), ["succeeded", "aborted", "preempted"])
             StateMachine.add_auto("RETRACT_ARM", motion.robust_move_to_offset(robot, (0, 0, -0.35)), ["succeeded", "aborted", "preempted"])
+            StateMachine.add_auto("TURN_OFF_GRIPPER_IF_NO_ITEM", motion.ReleaseGripperIfNoItem(robot), ['succeeded'])
             StateMachine.add_auto("CLEAR_SCENE_POSTGRASP", motion.ClearCollisionGeometry(robot), ["succeeded", "aborted"])
             StateMachine.add_auto("SETUP_COLLISION_SCENE_POSTGRASP", motion.AddFullPodCollisionGeometry(robot), ["succeeded", "aborted"])
             StateMachine.add_auto("ADD_IN_HAND_COLLISION_BOX", motion.AddInHandCollisionGeometry(robot), ["succeeded", "aborted"])

--- a/aurmr_tasks/src/aurmr_tasks/common/motion.py
+++ b/aurmr_tasks/src/aurmr_tasks/common/motion.py
@@ -452,7 +452,7 @@ class ReleaseGripperIfNoItem(State):
         self.robot = robot
 
     def execute(self, ud):
-        if self.robot.check_gripper_item():
+        if not self.robot.check_gripper_item():
             self.robot.open_gripper(return_before_done=True)
         return 'succeeded'
 

--- a/aurmr_tasks/src/aurmr_tasks/common/motion.py
+++ b/aurmr_tasks/src/aurmr_tasks/common/motion.py
@@ -446,6 +446,16 @@ class CheckGripperItem(State):
         ud["status"] = status
         return status
 
+class ReleaseGripperIfNoItem(State):
+    def __init__(self, robot):
+        State.__init__(self, input_keys=[], output_keys=[], outcomes=['succeeded'])
+        self.robot = robot
+
+    def execute(self, ud):
+        if self.robot.check_gripper_item():
+            self.robot.open_gripper(return_before_done=True)
+        return 'succeeded'
+
 class ClearCollisionGeometry(State):
     def __init__(self, robot):
         State.__init__(self, outcomes=["succeeded", "aborted"])


### PR DESCRIPTION
Before, when item grasp failed, suction noise still turned on which was quite annoying. Now, I turned the suction off when it failed to grasp the item.